### PR TITLE
fix: 解决ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/me/bytebeats/mns/handler/AbsStockHandler.java
+++ b/src/main/java/me/bytebeats/mns/handler/AbsStockHandler.java
@@ -89,12 +89,11 @@ public abstract class AbsStockHandler extends AbstractHandler implements UISetti
             if (isInHiddenMode()) {
                 name = PinyinUtils.toPinyin(name);
             }
-            if (i < stocks.size()) {//ArrayIndexOutOfBoundsException from issues: https://github.com/bytebeats/mns/issues/76
-                data[i] = new Object[]{name, stock.getSymbol(), stock.getLatestPrice(), stock.getChange(),
-                        stock.getChangeRatioString()};
+            data[i] = new Object[]{name, stock.getSymbol(), stock.getLatestPrice(), stock.getChange(),
+                    stock.getChangeRatioString()};
+            //ArrayIndexOutOfBoundsException from issues: https://github.com/bytebeats/mns/issues/76
+            if(i < stockColumnNames.length) {
                 columnTextColors.put(i, stock.getChange());
-            } else {
-                break;
             }
         }
         return data;


### PR DESCRIPTION
移除多余的if (i < stocks.size())判断。
确保columnTextColors的大小与stockColumnNames.length一致，避免ArrayIndexOutOfBoundsException。